### PR TITLE
[BOJ] 1780 종이의 개수

### DIFF
--- a/BaekJoon/1780.py
+++ b/BaekJoon/1780.py
@@ -1,0 +1,38 @@
+# BOJ 1780 종이의 개수
+# https://www.acmicpc.net/problem/1780
+
+from sys import stdin
+
+def solution(N, graph):
+    answer = {-1: 0, 0: 0, 1: 0}
+
+    # 종이가 모두 같은 수로 구성되어 있는가?
+    def check(x, y, N):
+        std = graph[y][x]
+        for ny in range(y,y+N):
+            for nx in range(x,x+N):
+                if std != graph[ny][nx]:
+                    return False
+        return True
+
+    # 분할 정복
+    def divideConquer(x, y, N):
+        if check(x, y, N):
+            answer[graph[y][x]] += 1
+            return
+        # 같은 크기의 종이 9개로 분할
+        N//=3
+        for dy in range(3):
+            for dx in range(3):
+                divideConquer(x+N*dx, y+N*dy, N)
+
+    divideConquer(0, 0, N)
+
+    return answer.values()
+
+N = int(stdin.readline())
+graph = [list(map(int,stdin.readline().split())) for _ in range(N)]
+
+result = solution(N, graph)
+for res in result:
+    print(res)


### PR DESCRIPTION
📒 **[알고리즘] BOJ 1780 종이의 개수 #Python**에 대한 자세한 내용은 [요기!](https://velog.io/@isayaksh/%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-BOJ-1780-%EC%A2%85%EC%9D%B4%EC%9D%98-%EA%B0%9C%EC%88%98-Python)